### PR TITLE
build: Add six requirement to install requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
         'requests[security]>=2.9',
         'jsonschema',
         'click',
+        'six>=1.4.0',  # six.moves added in six v1.4.0
     ],
       extras_require = {
         'develop': [


### PR DESCRIPTION
Resolves #35

The `six.moves` module 

https://github.com/yadage/yadage-schemas/blob/260fbc40ec5b8afa7d59c0dd00591e02e13774e4/yadageschemas/dialects/raw_with_defaults.py#L118

was added in `six` `v1.4.0`, setting the lower bound of `six>=1.4.0`.