### PR TITLE
ci: Remove unsupported Pythons from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,14 +19,14 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['2.7', '3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['2.7', '3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,12 +14,12 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v2
+    - name: Set up Python
+      uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.x'
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -21,14 +21,14 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v2
+    - name: Set up Python
+      uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.x'
 
     - name: Install build, check-manifest, and twine
       run: |

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,8 @@ setup(
     description = 'schemas for yadage and packtivity',
     include_package_data = True,
     packages = find_packages(),
-    # Support Python 3.7+ but keep legacy support for Python 2.7 until 2022
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*",
+    # Support Python 3.6+ but keep legacy support for Python 2.7 until 2022
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*",
     install_requires = [
         'jsonref',
         'pyyaml',

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,8 @@ setup(
     description = 'schemas for yadage and packtivity',
     include_package_data = True,
     packages = find_packages(),
-    # Support Python 3.6+ but keep legacy support for Python 2.7 until 2022
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*",
+    # Support Python 3.7+ but keep legacy support for Python 2.7 until 2022
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*",
     install_requires = [
         'jsonref',
         'pyyaml',


### PR DESCRIPTION
```
* Update GitHub Actions to latest versions.
* Remove Python 3.6 as unsupported in GHA.
* Add Python 3.11 to CI and use Python '3.x'.
```