### PR TITLE
fix: Add upper bound on jsonschema of 4.9.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
         'jsonref',
         'pyyaml',
         'requests[security]>=2.9',
-        'jsonschema',
+        'jsonschema<=4.9.1',  # c.f. https://github.com/yadage/yadage-schemas/issues/38
         'click',
         'six>=1.4.0',  # six.moves added in six v1.4.0
     ],


### PR DESCRIPTION
* Add upper bound of 'jsonschema<=4.9.1' as an emergency temporary workaround.
   - c.f. https://github.com/yadage/yadage-schemas/issues/38
* This should not be done, and should be viewed as temporary only for release v0.10.8.