### PR TITLE
chore: Update default branch from 'master' to 'main'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,10 @@ name: CI
 on:
   push:
     branches:
-    - master
+    - main
   pull_request:
     branches:
-    - master
+    - main
   # Run daily at 1:23 UTC
   schedule:
   - cron:  '23 1 * * *'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ name: Lint
 on:
   pull_request:
     branches:
-    - master
+    - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -2,10 +2,10 @@ name: publish distributions
 on:
   push:
     branches:
-    - master
+    - main
   pull_request:
     branches:
-    - master
+    - main
   release:
     types: [published]
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![DOI](https://zenodo.org/badge/54061494.svg)](https://zenodo.org/badge/latestdoi/54061494)
 [![PyPI version](https://badge.fury.io/py/yadage-schemas.svg)](https://badge.fury.io/py/yadage-schemas)
 
-[![CI](https://github.com/yadage/yadage-schemas/actions/workflows/ci.yml/badge.svg)](https://github.com/yadage/yadage-schemas/actions/workflows/ci.yml?query=branch%3Amaster)
+[![CI](https://github.com/yadage/yadage-schemas/actions/workflows/ci.yml/badge.svg)](https://github.com/yadage/yadage-schemas/actions/workflows/ci.yml?query=branch%3Amain)
 
 This package holds JSON schema definitions for preserving individual processing tasks of scientific workflows (referred to "packtivities" since they including information where to find their respective prepackage sofware environments) as well as schemas to define declaratively workflows that orchestrate multiple of these steps using directed acyclic graphs (DAGs)
 

--- a/yadageschemas/dialects/raw_with_defaults.py
+++ b/yadageschemas/dialects/raw_with_defaults.py
@@ -105,7 +105,7 @@ def generic_github_url(toplevel):
         repo, branch = repo
     else:
         repo = repo[0]
-        branch = 'master'
+        branch = 'main'
 
     url = 'https://raw.githubusercontent.com/{repo}/{branch}'.format(
         repo = repo,
@@ -151,7 +151,7 @@ def loader(toplevel):
                 repo = urllib.parse.quote(d['repo'],safe=''),
                 path = urllib.parse.quote(d['subpath']+path, safe=''),
                 ref = urllib.parse.quote(d['ref'],safe='')
-            ) 
+            )
         try:
             log.debug('trying to get uri %s',uri)
             if 'YADAGE_SCHEMA_LOAD_TOKEN' in os.environ:

--- a/yadageschemas/utils.py
+++ b/yadageschemas/utils.py
@@ -28,7 +28,7 @@ def schemabase_uri(schemadir):
     if schemadir == None:
         schemabase = 'file://'+os.path.abspath(default_schemadir)
     elif schemadir=='from-github':
-        schemabase = 'https://raw.githubusercontent.com/lukasheinrich/cap-schemas/master/schemas'
+        schemabase = 'https://raw.githubusercontent.com/yadage/yadage-schemas/main/schemas'
     else:
         schemabase = 'file://'+os.path.abspath(schemadir)
     return schemabase


### PR DESCRIPTION
* Additionally remap defaults to 'main' for GitHub specific code that will allow it.
   - Example of where 'master' is still needed: https://raw.githubusercontent.com/lukasheinrich/yadage-workflows/master
* Update URL redirect from "lukasheinrich/cap-schemas" to "yadage/yadage-schemas"