### PR TITLE
build: Drop Python 2 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['2.7', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
     - name: Checkout code

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,7 @@ setup(
     long_description_content_type = "text/markdown",
     include_package_data = True,
     packages = find_packages(),
-    # Support Python 3.7+ but keep legacy support for Python 2.7 until 2023
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*",
+    python_requires=">=3.7",
     install_requires = [
         'jsonref',
         'pyyaml',
@@ -40,9 +39,8 @@ setup(
         "Development Status :: 4 - Beta",
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
* Python 2 has been EOL since 2020-01-01 and other yadage ecosystem packages are already Python 3 only, so there is no need to still support Python 2.7.

```
* Python 2 has been EOL since 2020-01-01 and other yadage ecosystem
  packages are already Python 3 only, so there is no need to still
  support Python 2.7.
* Remove Python 2.7 from testing matrix in CI.
```