### PR TITLE
fix: Use importlib-resources over deprecated pkg_resources

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
         'jsonschema<=4.9.1',  # c.f. https://github.com/yadage/yadage-schemas/issues/38
         'click',
         'six>=1.4.0',  # six.moves added in six v1.4.0
+        'importlib-resources>=5.10;python_version<"3.9"' # for accessing package filepaths
     ],
       extras_require = {
         'develop': [

--- a/yadageschemas/__init__.py
+++ b/yadageschemas/__init__.py
@@ -7,11 +7,13 @@ except ImportError:
     # https://docs.python.org/3/library/importlib.resources.html#importlib.resources.files
     from importlib_resources import files
 
+# FIXME: Import order must be before yadageschemas.utils to avoid circular import
+schemadir = files("yadageschemas")
+
 from . import dialects
 from .utils import WithJsonRefEncoder
 from .validator import validate_spec
 
-schemadir = files("yadageschemas")
 
 def load(spec, specopts, validate = True, validopts = None, dialect = 'raw_with_defaults'):
     data = dialects.handlers[dialect](spec, specopts)

--- a/yadageschemas/__init__.py
+++ b/yadageschemas/__init__.py
@@ -1,11 +1,17 @@
 import json
-import pkg_resources
 
-schemadir = pkg_resources.resource_filename('yadageschemas','')
+try:
+    from importlib.resources import files
+except ImportError:
+    # Support Python 3.8 as importlib.resources added in Python 3.9
+    # https://docs.python.org/3/library/importlib.resources.html#importlib.resources.files
+    from importlib_resources import files
 
-from .utils import WithJsonRefEncoder
 from . import dialects
+from .utils import WithJsonRefEncoder
 from .validator import validate_spec
+
+schemadir = files("yadageschemas")
 
 def load(spec, specopts, validate = True, validopts = None, dialect = 'raw_with_defaults'):
     data = dialects.handlers[dialect](spec, specopts)


### PR DESCRIPTION
Resolves #50 

* Add importlib-resources as an install dependency for Python 3.8 as Python 3.12 deprecates and removes pkg_resources.
* Replace use of pkg_resources.resource_filename with importlib.resources.files for Python 3.9+ and importlib_resources.files for Python 3.8.
* Apply isort.
* Note import order issue to be fixed.

```
* Add importlib-resources as an install dependency for Python 3.8 as Python 3.12 deprecates
  and removes pkg_resources.
* Replace use of pkg_resources.resource_filename with importlib.resources.files
  for Python 3.9+ and importlib_resources.files for Python 3.8.
* Apply isort.
* Note import order issue to be fixed.
```