### PR TITLE
ci: Use 'yadage_schemas' for all dist name

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -49,7 +49,7 @@ jobs:
       run: twine check dist/*
 
     - name: List contents of sdist
-      run: python -m tarfile --list dist/yadage-schemas-*.tar.gz
+      run: python -m tarfile --list dist/yadage_schemas-*.tar.gz
 
     - name: List contents of wheel
       run: python -m zipfile --list dist/yadage_schemas-*.whl


### PR DESCRIPTION
* Use the now standard underscore "_" for dist names.