### PR TITLE
ci: Add GitHub artifact attestations to package distribution

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -45,6 +45,13 @@ jobs:
       run: |
         python -m build .
 
+    - name: Generate artifact attestation for sdist and wheel
+      # If publishing to PyPI
+      if: github.event_name == 'release' && github.event.action == 'published' && github.repository == 'yadage/yadage-schemas'
+      uses: actions/attest-build-provenance@534b352d658f90498fd148d231fdbf88f3886a3a # v1.3.1
+      with:
+        subject-path: "dist/yadage_schemas-*"
+
     - name: Verify the distribution
       run: twine check dist/*
 

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -17,10 +17,17 @@ on:
         - false
         - true
 
+permissions:
+  contents: read
+
 jobs:
   build-and-publish:
     name: Build and publish Python distro to (Test)PyPI
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
+
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
* Add generation of GitHub artifact attestations to built sdist and wheel before upload. c.f.:
   - https://github.blog/2024-05-02-introducing-artifact-attestations-now-in-public-beta/
   - https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds